### PR TITLE
Hydrogen bond calculations and handling pairwise cutoffs for distance-based bonds 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # James
 
-<img src="resources/hbond_fig.png" width="300" />
+<img src="https://github.com/amritagos/james/blob/main/resources/hbond_fig.png?raw=true" width="300" />
 
 A small C++ library to create Network objects (with hydrogen bonds, distance-based cutoffs), and System (similar to the ASE Atoms) objects. Image rendered using [`solvis`](https://github.com/amritagos/solvis).
 

--- a/james/include/bondfinder.hpp
+++ b/james/include/bondfinder.hpp
@@ -28,7 +28,7 @@ void add_hbonds(Graph::NetworkBase<WeightType> &network,
                 const std::vector<int> &donor_atom_types,
                 const std::vector<int> &acceptor_atom_types,
                 const std::vector<int> &h_atom_types,
-                double cutoff_distance = 3.5, double max_angle_deg = 30,
+                double cutoff_distance = 3.2, double max_angle_deg = 30,
                 bool ignore_hydrogens = true) {
   // Lambda for checking if a particular atom type (target) is one of allowed
   // atom types
@@ -71,6 +71,11 @@ void add_hbonds(Graph::NetworkBase<WeightType> &network,
               double hda_angle =
                   Misc::angleABCdeg(h_atom.position, donor.position,
                                     acceptor.position, system.box);
+
+              // Somehow we need to restrict the angle to less than 90
+              if (hda_angle > 90) {
+                hda_angle = 180 - hda_angle;
+              }
               if (hda_angle > max_angle_deg) {
                 continue;
               }

--- a/james/include/pairtypes.hpp
+++ b/james/include/pairtypes.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <stdexcept>
+#include <unordered_map>
+#include <vector>
+
+namespace James::Bond {
+// Commutative pair class
+class Pair {
+public:
+  int typeA{};
+  int typeB{};
+
+  Pair(int typeA, int typeB) : typeA(typeA), typeB(typeB) {}
+
+  // overloaded equality operator
+  friend bool operator==(const Pair &p1, const Pair &p2) {
+    if ((p1.typeA == p2.typeA && p1.typeB == p2.typeB) ||
+        (p1.typeA == p2.typeB && p1.typeB == p2.typeA)) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+};
+
+// Custom hash for the Pair class
+// Here we implement the custom hash as a standalone function object.
+struct MyHash {
+  std::size_t operator()(const Pair &s) const noexcept {
+    std::size_t h1 = std::hash<int>{}(s.typeA);
+    std::size_t h2 = std::hash<int>{}(s.typeB);
+    return h1 ^ (h2 << 1);
+  }
+
+  // Create an unordered_map with the Pair as the key and the cutoff as the
+  // value
+  std::unordered_map<Pair, double, MyHash>
+  create_pairtype_cutoffs(std::vector<Pair> &pairs,
+                          std::vector<double> &cutoffs) {
+    auto cutoff_map = std::unordered_map<Pair, double, MyHash>{};
+
+    if (pairs.size() != cutoffs.size()) {
+      std::runtime_error("Inconsistent Pair and cutoff values\n");
+    }
+
+    for (size_t i = 0; i < pairs.size(); i++) {
+      cutoff_map[pairs[i]] = cutoffs[i];
+    }
+
+    return cutoff_map;
+  }
+};
+} // namespace James::Bond

--- a/james/include/pairtypes.hpp
+++ b/james/include/pairtypes.hpp
@@ -32,25 +32,29 @@ struct MyHash {
   std::size_t operator()(const Pair &s) const noexcept {
     std::size_t h1 = std::hash<int>{}(s.typeA);
     std::size_t h2 = std::hash<int>{}(s.typeB);
-    return h1 ^ (h2 << 1);
-  }
-
-  // Create an unordered_map with the Pair as the key and the cutoff as the
-  // value
-  std::unordered_map<Pair, double, MyHash>
-  create_pairtype_cutoffs(std::vector<Pair> &pairs,
-                          std::vector<double> &cutoffs) {
-    auto cutoff_map = std::unordered_map<Pair, double, MyHash>{};
-
-    if (pairs.size() != cutoffs.size()) {
-      std::runtime_error("Inconsistent Pair and cutoff values\n");
+    if (s.typeA > s.typeB) {
+      return h1 ^ h2;
+    } else {
+      return h2 ^ h1;
     }
-
-    for (size_t i = 0; i < pairs.size(); i++) {
-      cutoff_map[pairs[i]] = cutoffs[i];
-    }
-
-    return cutoff_map;
   }
 };
+
+// Create an unordered_map with the Pair as the key and the cutoff as the
+// value
+inline std::unordered_map<Pair, double, MyHash>
+create_pairtype_cutoffs(std::vector<Pair> &pairs,
+                        std::vector<double> &cutoffs) {
+  auto cutoff_map = std::unordered_map<Pair, double, MyHash>{};
+
+  if (pairs.size() != cutoffs.size()) {
+    std::runtime_error("Inconsistent Pair and cutoff values\n");
+  }
+
+  for (size_t i = 0; i < pairs.size(); i++) {
+    cutoff_map[pairs[i]] = cutoffs[i];
+  }
+
+  return cutoff_map;
+}
 } // namespace James::Bond

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,7 @@ james_dep = declare_dependency(include_directories : inc, dependencies: graphlib
 tests = [
   ['Test_System', 'test/test_system.cpp'],
   ['Test_Hbond', 'test/test_hbond.cpp'],
+  ['Test_Pairtypes', 'test/test_pairtypes.cpp'],
 ]
 
 test_inc = []

--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,7 @@ tests = [
   ['Test_System', 'test/test_system.cpp'],
   ['Test_Hbond', 'test/test_hbond.cpp'],
   ['Test_Pairtypes', 'test/test_pairtypes.cpp'],
+  ['Test_Distance_Bonds', 'test/test_dist_bonds.cpp'],
 ]
 
 test_inc = []

--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,7 @@ james_dep = declare_dependency(include_directories : inc, dependencies: graphlib
 
 tests = [
   ['Test_System', 'test/test_system.cpp'],
+  ['Test_Hbond', 'test/test_hbond.cpp'],
 ]
 
 test_inc = []

--- a/test/test_dist_bonds.cpp
+++ b/test/test_dist_bonds.cpp
@@ -1,0 +1,57 @@
+#include "bondfinder.hpp"
+#include "pairtypes.hpp"
+#include "system.hpp"
+#include "undirected_network.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
+#include <cstddef>
+#include <vector>
+
+TEST_CASE("Test that distance-based bonds can be created by providing pairwise "
+          "cutoffs or a global cutoff",
+          "[DistanceBonds]") {
+  // Create a system with one water molecule and one Chloride ion
+  auto system = James::Atoms::System();
+  system.box = std::vector<double>{49.4752565268, 49.4752565268, 49.4752565268};
+  system.boxLo =
+      std::vector<double>{-12.457628299, -12.457628299, -12.457628299};
+  // Positions of all the atoms (O, H, H, Cl)
+  auto positions =
+      std::vector<std::vector<double>>{{26.6679, 23.3139, 22.8734},
+                                       {26.0598, 22.5748, 22.8577},
+                                       {26.7405, 23.5454, 23.7993},
+                                       {25.1689, 20.8364, 22.0004}};
+
+  system.push_back(James::Atoms::Atom(1, 1, 1, positions[0])); // O atom
+  system.push_back(James::Atoms::Atom(2, 2, 1, positions[1])); // H atom (h1)
+  system.push_back(James::Atoms::Atom(3, 2, 1, positions[2])); // H atom (h2)
+  system.push_back(James::Atoms::Atom(4, 4, 2, positions[3])); // Cl ion
+
+  // Type and index information of all the atoms
+  int o_type = 1;
+  int h_type = 2;
+  size_t o_index = 0;
+  auto pair_oh = James::Bond::Pair(o_type, h_type);
+
+  // The undirected network
+  auto network = Graph::UndirectedNetwork<double>(system.n_atoms());
+
+  // Create distance based cutoffs (intra-molecular water bonds)
+  auto pairs = std::vector<James::Bond::Pair>{pair_oh};
+  auto cutoffs = std::vector<double>{1.0};
+  James::Bond::add_distance_based_bonds(network, system, pairs, cutoffs);
+
+  // There should be two bonds between the O and H
+  REQUIRE(network.n_edges(o_index) == 2);
+
+  // The total number of edges should also be 2
+  REQUIRE(network.n_edges() == 2);
+
+  // Test the global cutoff distance criterion
+  network.clear();
+  James::Bond::add_distance_based_bonds(network, system, 3.5);
+
+  // The total number of edges should be 5
+  REQUIRE(network.n_edges() == 5);
+}

--- a/test/test_hbond.cpp
+++ b/test/test_hbond.cpp
@@ -1,0 +1,76 @@
+#include "bondfinder.hpp"
+#include "catch2/matchers/catch_matchers.hpp"
+#include "fmt/core.h"
+#include "fmt/ostream.h"
+#include "system.hpp"
+#include "undirected_network.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
+#include <cstddef>
+#include <vector>
+
+TEST_CASE("Test that a hydrogen bond can be found between a Cl- ion and water "
+          "molecule",
+          "[Hbond]") {
+  // Create a system with one water molecule and one Chloride ion
+  auto system = James::Atoms::System();
+  system.box = std::vector<double>{49.4752565268, 49.4752565268, 49.4752565268};
+  system.boxLo =
+      std::vector<double>{-12.457628299, -12.457628299, -12.457628299};
+  // Positions of all the atoms (O, H, H, Cl)
+  auto positions =
+      std::vector<std::vector<double>>{{26.6679, 23.3139, 22.8734},
+                                       {26.0598, 22.5748, 22.8577},
+                                       {26.7405, 23.5454, 23.7993},
+                                       {25.1689, 20.8364, 22.0004}};
+
+  system.push_back(James::Atoms::Atom(1, 1, 1, positions[0])); // O atom
+  system.push_back(James::Atoms::Atom(2, 2, 1, positions[1])); // H atom (h1)
+  system.push_back(James::Atoms::Atom(3, 2, 1, positions[2])); // H atom (h2)
+  system.push_back(James::Atoms::Atom(4, 4, 2, positions[3])); // Cl ion
+
+  // Type and index information of all the atoms
+  int o_type = 1;
+  int h_type = 2;
+  int cl_type = 4;
+  size_t cl_index = 3;
+
+  // The undirected network
+  auto network = Graph::UndirectedNetwork<double>(system.n_atoms());
+
+  // Information needed for hydrogen bonds
+  auto donor_atom_types = std::vector<int>{o_type};
+  auto acceptor_atom_types = std::vector<int>{cl_type, o_type};
+  auto h_atom_types = std::vector<int>{h_type};
+  double donor_acceptor_cutoff = 3.2;
+  double max_angle_deg = 30;
+  // Add the hydrogen bond between the H and the Cl
+  James::Bond::add_hbonds(network, system, donor_atom_types,
+                          acceptor_atom_types, h_atom_types,
+                          donor_acceptor_cutoff, max_angle_deg, false);
+
+  // There should be one hydrogen bond between the Cl and H
+  REQUIRE(network.n_edges(cl_index) == 1);
+
+  // The total number of edges should also be 1
+  REQUIRE(network.n_edges() == 1);
+
+  // Find the H in the hydrogen bond
+  auto h_neighbours = network.get_neighbours(cl_index);
+  INFO(fmt::format("Hydrogen index in the hydrogen bond is {} \n",
+                   h_neighbours[0]));
+
+  // Get the angle HDA and check that it is smaller than the maximum angle
+  // cutoff A : acceptor (Cl-) D: donor (O) You can also get all the positions
+  // using system.
+  auto a_pos = system.atoms[3].position; // Cl position
+  auto d_pos = system.atoms[0].position; // O position
+  for (auto h_index : h_neighbours) {
+    auto h_pos = system.atoms[h_index].position;
+    double hda_angle =
+        James::Misc::angleABCdeg(h_pos, d_pos, a_pos, system.box);
+    INFO(fmt::format("HDA angle in degrees = {}\n", hda_angle));
+    REQUIRE(hda_angle < 30);
+  }
+}

--- a/test/test_pairtypes.cpp
+++ b/test/test_pairtypes.cpp
@@ -1,0 +1,29 @@
+#include "pairtypes.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
+#include <vector>
+
+TEST_CASE("Test the Pair class", "[Pair]") {
+  auto pair31 = James::Bond::Pair(3, 1);
+  auto pair13 = James::Bond::Pair(1, 3);
+
+  // Commutative pairs should be the same
+  REQUIRE(pair13 == pair31);
+}
+
+TEST_CASE("Test that you can make an unordered_map with Pairs as keys",
+          "[PairCutoffMap]") {
+  auto pair13 = James::Bond::Pair(1, 3);
+  auto pair11 = James::Bond::Pair(1, 1);
+  auto pairs = std::vector<James::Bond::Pair>{pair13, pair11};
+  auto cutoffs = std::vector<double>{3.2, 4.0};
+  auto pair_cutoff_map = James::Bond::create_pairtype_cutoffs(pairs, cutoffs);
+
+  REQUIRE(pair_cutoff_map[pair13] == cutoffs[0]);
+  REQUIRE(pair_cutoff_map[pair11] == cutoffs[1]);
+
+  // Update 1-3
+  pair_cutoff_map[James::Bond::Pair(3, 1)] = 3.5;
+  REQUIRE(pair_cutoff_map[pair13] == 3.5);
+}


### PR DESCRIPTION
- Added a test for a single hydrogen bond, corresponding to a hydrogen bond between the Cl- ion and O atom in a water molecule. 
- Commutative Pair class, to handle bond cutoffs for pairs of types. (Also added unit test)
- Can now create distance-based bonds: either by providing pairwise cutoffs, or a global cutoff that will ignore pair types. Unit test added for the same.
- Changed URL of image to absolute raw URL in README (minor change).