### PR TITLE
Optionally write out paths with atom IDs or indices

### DIFF
--- a/james/include/pathfinder.hpp
+++ b/james/include/pathfinder.hpp
@@ -3,9 +3,20 @@
 #include "network_operations.hpp"
 #include "system.hpp"
 #include <cstddef>
+#include <cstdio>
 #include <vector>
 
 namespace James::Path {
+
+enum class WriteIdentifier { AtomID, Index };
+
+/* Converts a path with indices in it to atom IDs from the System object */
+inline void convert_path_to_ids(std::vector<int> &path,
+                                const James::Atoms::System &system) {
+  for (auto &ele : path) {
+    ele = system.atoms[ele].id;
+  }
+}
 
 /*Checks to make sure that intermediate members are only of the allowed atom
  * types. This is only an issue if the size is greater than 2, since the end
@@ -50,7 +61,8 @@ find_ion_pairs(size_t source, Graph::NetworkBase<WeightType> &network,
                const James::Atoms::System &system,
                const std::vector<int> &destination_atom_types,
                const std::vector<int> &intermediate_atom_types,
-               std::optional<int> max_depth) {
+               std::optional<int> max_depth,
+               WriteIdentifier identifier = WriteIdentifier::AtomID) {
   // Lambda for checking if a particular atom type (target) is one of allowed
   // atom types
   auto atom_type_found = [&](const std::vector<int> &atom_types, int target) {
@@ -89,7 +101,12 @@ find_ion_pairs(size_t source, Graph::NetworkBase<WeightType> &network,
       // Sanity check for the paths found
       for (auto &test_path : shortest_paths) {
         if (check_ion_pair_path(test_path, system, intermediate_atom_types)) {
-          ion_pairs.push_back(test_path);
+          if (identifier == WriteIdentifier::AtomID) {
+            convert_path_to_ids(test_path, system);
+            ion_pairs.push_back(test_path);
+          } else if (identifier == WriteIdentifier::Index) {
+            ion_pairs.push_back(test_path);
+          }
         }
       }
     }

--- a/james/include/system.hpp
+++ b/james/include/system.hpp
@@ -19,7 +19,7 @@ struct Atom {
   int type{}; // Type number of the atom (could be an atomic number, or type
               // number as in LAMMPS)
   std::optional<int> mol_id = std::nullopt; // Molecule identifier
-  std::vector<double> position{};     // Position vector 
+  std::vector<double> position{};           // Position vector
 };
 
 class System {

--- a/test/test_ion_pairs.cpp
+++ b/test/test_ion_pairs.cpp
@@ -110,7 +110,7 @@ TEST_CASE("Test that ion pairs can be found for a system with an Fe3+ center, "
       {1, 11, 10, 0}, {2, 5, 4, 0}, {3, 14, 13, 0}};
   auto ion_pairs_with_hydrogens = James::Path::find_ion_pairs(
       fe_index, network, system, destination_atom_types,
-      intermediate_atom_types, max_depth);
+      intermediate_atom_types, max_depth, James::Path::WriteIdentifier::Index);
   INFO(fmt::format("Number of ion pairs found is {}",
                    ion_pairs_with_hydrogens.size()));
 
@@ -137,7 +137,7 @@ TEST_CASE("Test that ion pairs can be found for a system with an Fe3+ center, "
       std::vector<std::vector<int>>{{1, 10, 0}, {2, 4, 0}, {3, 13, 0}};
   auto ion_pairs_no_hydrogens = James::Path::find_ion_pairs(
       fe_index, network, system, destination_atom_types,
-      intermediate_atom_types, max_depth);
+      intermediate_atom_types, max_depth, James::Path::WriteIdentifier::Index);
   INFO(fmt::format("Number of ion pairs found (ignoring H) is {}",
                    ion_pairs_with_hydrogens.size()));
 

--- a/test/test_ion_pairs.cpp
+++ b/test/test_ion_pairs.cpp
@@ -149,6 +149,17 @@ TEST_CASE("Test that ion pairs can be found for a system with an Fe3+ center, "
   max_depth = 1;
   ion_pairs_no_hydrogens = James::Path::find_ion_pairs(
       fe_index, network, system, destination_atom_types,
-      intermediate_atom_types, max_depth);
+      intermediate_atom_types, max_depth, James::Path::WriteIdentifier::AtomID);
   REQUIRE(ion_pairs_no_hydrogens.size() == 0);
+
+  // Show that you can find ion pair paths such that each element is the atom
+  // ID, not the index in the System object
+  max_depth = 3; // inclusive
+  auto ion_pairs_no_h_required_ids =
+      std::vector<std::vector<int>>{{2, 11, 1}, {3, 5, 1}, {4, 14, 1}};
+  auto ion_pairs_no_hydrogens_ids = James::Path::find_ion_pairs(
+      fe_index, network, system, destination_atom_types,
+      intermediate_atom_types, max_depth, James::Path::WriteIdentifier::AtomID);
+  REQUIRE_THAT(ion_pairs_no_hydrogens_ids,
+               Catch::Matchers::RangeEquals(ion_pairs_no_h_required_ids));
 }


### PR DESCRIPTION
Using the enum class `WriteIdentifier`, it is possible to write out ion pairs as paths with atom IDs (by default) or by indices in the System object. Unit tests were written for the same. 