### PR TITLE
Develop: Removed fmt dependency in library

### DIFF
--- a/james/include/bondcorrel.hpp
+++ b/james/include/bondcorrel.hpp
@@ -4,6 +4,7 @@
 #include "undirected_network.hpp"
 #include <cmath>
 #include <cstddef>
+#include <iostream>
 #include <optional>
 #include <stdexcept>
 #include <vector>
@@ -217,8 +218,9 @@ time_correlation_function(const std::vector<std::vector<T>> &c_ij_time_series,
 
   if (calc_upto_tau.has_value()) {
     if (calc_upto_tau.value() > max_tau) {
-      fmt::print("Warning: You set calc_upto_tau to a value greater than "
-                 "max_tau. Setting to max_tau.\n");
+      std::cerr << "Warning: You set calc_upto_tau to a value greater than "
+                   "max_tau. Setting to max_tau."
+                << std::endl;
       calc_upto_tau = max_tau;
     }
   } else {

--- a/test/test_system.cpp
+++ b/test/test_system.cpp
@@ -20,7 +20,7 @@ TEST_CASE("Test the system", "[System]") {
 
   // Test that you can get the index of an Atom given the ID
   REQUIRE(system.index_from_id(1).value() == 0);
-  REQUIRE(system.index_from_id(3)==std::nullopt);
+  REQUIRE(system.index_from_id(3) == std::nullopt);
 
   // Test that the distance between the O and Cl is 3.02442
   double dist_required = 3.02442;


### PR DESCRIPTION
fmt is still a dependency for the tests and examples, but should not be compulsory in the main library.